### PR TITLE
Add script to generate TXF file for TurboTax desktop

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # Schwab 1099-B Converter
 
-The purpose of these two scripts is to automate entering stock sales from the
-Schwab EAC 1099-B form into TurboTax Online.
+The purpose of these scripts is to automate entering stock sales from the
+Schwab EAC 1099-B form into TurboTax Online or Desktop.
+
+## TurboTax Online
 
 There are several steps to this process, but it does work. And it can save a
 lot of time trying to enter the transaction manually.
@@ -64,3 +66,19 @@ lot of time trying to enter the transaction manually.
     step 8 if you need to add more entries.
 
 11. That's it. Hopefully all of your transactions are now entered into TurboTax.
+
+# TurboTax Desktop
+
+Complete Steps 1 through 3 as described for TurboTax online, obtaining an `entries.json` file. Then,
+instead of using this file in Chrome, run the following command to convert it to a Tax eXchange
+Format (TXF) file that TurboTax Desktop can process:
+
+`$ ./.json-to-txf entries.json > entries.txf`
+
+In TurboTax, import `entries.txf` via the File -> Import -> From Accounting Software menu. Verify
+that the short- and long-term totals imported as expected.
+
+If TurboTax says it needs "more info" for the imported transcations, click through each sale
+manually and select "stock" from the long list of options presented. All other relevant data
+should already be filled in, though it's a good idea to verfiy each sale individually against your
+Form 1099-B.

--- a/README.md
+++ b/README.md
@@ -43,8 +43,10 @@ lot of time trying to enter the transaction manually.
    area of the browser, and paste. This won't take any action other than defining a bunch of
    functions.
 
-7. Now do the same for the contents of the `entries.json` file created above. Copy the contents.
-   Paste it into the console window.
+7. Now, copy the contents of the `entries.json` file created above. In the console, assign the 
+   generated JSON to a variable as follows:
+
+   `> entries = [paste entries.json here]`
 
 8. Now the fun begins. In the console, type:
 

--- a/convert-1099b-json.py
+++ b/convert-1099b-json.py
@@ -3,6 +3,8 @@
 See README.md for instructions on using this script.
 '''
 
+from __future__ import print_function
+
 import sys
 import json
 
@@ -23,14 +25,14 @@ total_num_records = 0
 def print_and_zero_totals():
   global total_num_records, total_shares, total_proceeds, total_basis, total_wash
 
-  print >>sys.stderr, "********"
-  print >>sys.stderr, "Total # records read: %d" % total_num_records
-  print >>sys.stderr, 'Total shares: %d' % total_shares
-  print >>sys.stderr, "Verify these totals with the summary of the last page of the Schwab Statement"
-  print >>sys.stderr, "Total Proceeds: $%.2f" % total_proceeds
-  print >>sys.stderr, "Total Basis: $%.2f" % total_basis
-  print >>sys.stderr, "Total Wash: $%.2f" % total_wash
-  print >>sys.stderr
+  print("********", file=sys.stderr)
+  print("Total # records read: %d" % total_num_records, file=sys.stderr)
+  print('Total shares: %d' % total_shares, file=sys.stderr)
+  print("Verify these totals with the summary of the last page of the Schwab Statement", file=sys.stderr)
+  print("Total Proceeds: $%.2f" % total_proceeds, file=sys.stderr)
+  print("Total Basis: $%.2f" % total_basis, file=sys.stderr)
+  print("Total Wash: $%.2f" % total_wash, file=sys.stderr)
+  print("", file=sys.stderr)
   total_num_records = 0
   total_shares = 0
   total_proceeds = 0
@@ -41,7 +43,7 @@ input_fns = sys.argv[1:]
 for fn in input_fns:
   with open(fn, 'r') as f:
     lines = [l.strip() for l in f.readlines()]
-    print >>sys.stderr, "Read a total of %d lines from %s " % (len(lines), fn)
+    print("Read a total of %d lines from %s " % (len(lines), fn), file=sys.stderr)
 
     input_line = 0
     short_term = True
@@ -67,7 +69,7 @@ for fn in input_fns:
         break
 
       if len(lines) < input_line + 4:
-        #print >>sys.stderr, 'WARNING: Trailing content at end of file: \n%s' % repr(lines[input_line:])
+        #print('WARNING: Trailing content at end of file: \n%s' % repr(lines[input_line:]), file=sys.stderr)
         break
 
       if not (lines[input_line].startswith('3825') or lines[input_line].startswith('0207')):
@@ -78,7 +80,7 @@ for fn in input_fns:
         continue
 
       if verbose:
-        print >>sys.stderr, "Read CUSIP: %s" % lines[input_line]
+        print("Read CUSIP: %s" % lines[input_line], file=sys.stderr)
 
       transaction = {}
       #description, acq_date, sale_date, proceeds, basis, wash]
@@ -89,7 +91,7 @@ for fn in input_fns:
         sys.exit('ERROR: Parsing input line %d: %s' % (input_line+1, lines[input_line]))
 
       if verbose:
-        print >>sys.stderr, "Next line: %s" % lines[input_line]
+        print("Next line: %s" % lines[input_line], file=sys.stderr)
 
       quantity = int(float(parts[0]))
       total_shares += quantity
@@ -101,7 +103,7 @@ for fn in input_fns:
 
       input_line += 1
       if verbose:
-        print >>sys.stderr, "Next line: %s" % lines[input_line]
+        print("Next line: %s" % lines[input_line], file=sys.stderr)
       parts = lines[input_line].split(' ')
       len(parts) == 3 or sys.exit('ERROR: Parsing input line %d: %s' % (input_line+1, lines[input_line]))
       (acq_date, proceeds, basis) = parts
@@ -126,7 +128,7 @@ for fn in input_fns:
 
       input_line += 1
       if verbose:
-        print >>sys.stderr, "Next line: %s" % lines[input_line]
+        print("Next line: %s" % lines[input_line], file=sys.stderr)
       parts = lines[input_line].split(' ')
       len(parts) == 2 or (len(parts) == 3 and wash) or sys.exit('ERROR: Parsing input line %d: %s' % (input_line+1, lines[input_line]))
       sale_date = parts[0]
@@ -149,9 +151,9 @@ for fn in input_fns:
 
       if verbose:
         if wash:
-          print >>sys.stderr, "Read record: (symbol:%s,\tacq_date:%s,\tsale_date:%s,\tquantity:%d,\tproceeds:$%.2f,\tbasis:$%.2f,\twash:$%.2f)" % (symbol, acq_date, sale_date, quantity, proceeds, basis, wash)
+          print("Read record: (symbol:%s,\tacq_date:%s,\tsale_date:%s,\tquantity:%d,\tproceeds:$%.2f,\tbasis:$%.2f,\twash:$%.2f)" % (symbol, acq_date, sale_date, quantity, proceeds, basis, wash), file=sys.stderr)
         else:
-          print >>sys.stderr, "Read record: (symbol:%s,\tacq_date:%s,\tsale_date:%s,\tquantity:%d,\tproceeds:$%.2f,\tbasis:$%.2f)" % (symbol, acq_date, sale_date, quantity, proceeds, basis)
+          print("Read record: (symbol:%s,\tacq_date:%s,\tsale_date:%s,\tquantity:%d,\tproceeds:$%.2f,\tbasis:$%.2f)" % (symbol, acq_date, sale_date, quantity, proceeds, basis), file=sys.stderr)
       total_num_records += 1
 
       total_proceeds += proceeds
@@ -161,9 +163,9 @@ for fn in input_fns:
 
     print_and_zero_totals()
 
-print 'entries = '
+print('entries = ')
 json.dump(short_sales + long_sales, sys.stdout)
-print ''
+print('')
 
-print >>sys.stderr, '%d short term transaction processed' % len(short_sales)
-print >>sys.stderr, '%d long term transaction processed' % len(long_sales)
+print('%d short term transaction processed' % len(short_sales), file=sys.stderr)
+print('%d long term transaction processed' % len(long_sales), file=sys.stderr)

--- a/convert-1099b-json.py
+++ b/convert-1099b-json.py
@@ -163,9 +163,7 @@ for fn in input_fns:
 
     print_and_zero_totals()
 
-print('entries = ')
 json.dump(short_sales + long_sales, sys.stdout)
-print('')
 
 print('%d short term transaction processed' % len(short_sales), file=sys.stderr)
 print('%d long term transaction processed' % len(long_sales), file=sys.stderr)

--- a/json-to-txf.py
+++ b/json-to-txf.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+"""Convert JSON file from convert-1099b-json.py to TXF for import.
+See README.md for instructions on using this script.
+"""
+
+from __future__ import print_function
+
+import datetime
+import json
+import sys
+
+transactions = json.load(sys.stdin)
+
+# TXF header:
+print('V042') # Version (https://turbotax.intuit.com/txf/TXF042.jsp)
+print('Aschwab1099b txf-to-json.py') # Accounting program name
+print('D' + datetime.date.today().strftime('%m/%d/%Y')) # Export date
+print('^') # TXF record delimiter
+
+for transaction in transactions:
+    # By using the Copy B taxrefs (711 and 713 for short-term and long-term
+    # transactions, respectively), we indicate to the tax software that the
+    # cost basis for these sales was *not* reported to the IRS. (This leads to
+    # Box B being checked when the tax software prepares Form 8949.)
+    #
+    # Per the TXF specification, it's okay to always use record format 5 even
+    # if no wash sale occurred, in which case we just leave the wash sale
+    # amount blank ('$').
+
+    # TXF common record fields:
+    print('TD') # Type: Detail
+    if (transaction['category'] == '2'):
+      print('N711') # Refnum: ST gain/loss 8949 Copy B
+    else:
+      print('N713') # Refnum: LT gain/loss 8949 Copy B
+
+    # TXF record format 5:
+    print('P%s' % transaction['desc']) # Security
+    print('D%s' % transaction['acq']) # Date acquired
+    print('D%s' % transaction['sale']) # Date sold
+    print('$%s' % transaction['basis']) # Cost basis
+    print('$%s' % transaction['proceeds']) # Sales net
+    if transaction['wash']:
+        print('$%s' % transaction['wash']) # Disallowed wash sale amount
+    else:
+        print('$') # Disallowed wash sale amount
+    print('^') # TXF record delimiter


### PR DESCRIPTION
There are a few scripts that output TXF files for Schwab 1099s around floating around GitHub, but they're all lacking in various ways. Your script seems the most complete, and also the cleanest since the 1099 parser outputs a JSON file, which let me write a trivial script to process that JSON and converts it to TXF format. (I have verified this worked correctly on my own Form 1099-B from Schwab's EAC for the 2018 tax year.)

This involved a minor change to the process for TurboTax Online. Since I need the generated JSON file to be JSON, you now have to type the `entries = [paste JSON here]` portion of the variable assignment into the JS console manually for the online flow. I think that's okay, but let me know if you have a better idea.

While I was in here, I also made a trivial update to the existing script so it works in both Python 2 and Python 3, because I'm running in MSYS2 on Windows, and `/usr/bin/python` already defaults to Python 3 there.