### PR TITLE
Update script shebang lines for Python 3 (and fix a small typo in the README)

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Complete Steps 1 through 3 as described for TurboTax online, obtaining an `entri
 instead of using this file in Chrome, run the following command to convert it to a Tax eXchange
 Format (TXF) file that TurboTax Desktop can process:
 
-`$ ./json-to-txf < entries.json > entries.txf`
+`$ ./json-to-txf.py < entries.json > entries.txf`
 
 In TurboTax, import `entries.txf` via the File -> Import -> From Accounting Software menu. Verify
 that the short- and long-term totals imported as expected.

--- a/convert-1099b-json.py
+++ b/convert-1099b-json.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 '''Convert Schwab EAC 1099 to JSON format.
 See README.md for instructions on using this script.
 '''

--- a/json-to-txf.py
+++ b/json-to-txf.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Convert JSON file from convert-1099b-json.py to TXF for import.
 See README.md for instructions on using this script.
 """


### PR DESCRIPTION
Here's my yearly pull request. :) Most distros have moved to Python three these days, so I think it's more useful to use `python3` in the shebang lines than just `python`. (The scripts themselves appear to work fine in Python 3.)

I also fixed the `json-to-txf` command in the README so it actually works.